### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ Gruntfile.js:
 ```js
 grunt.initConfig({
   injector: {
-    options: {},
+    options: {
+      addRootSlash: false
+    },
     local_dependencies: {
       files: {
         'index.html': ['**/*.js', '**/*.css'],


### PR DESCRIPTION
Output HTML in the readme.md won't be accurate unless the `addRootSlash: false` option is added. Alternatively, the example starting line  171 should look like:

``` html
<!DOCTYPE html>
<html>
<head>
  <title>Example</title>
  <!-- injector:css -->
  <link rel="stylesheet" href="/file1.css">
  <link rel="stylesheet" href="/file2.css">
  <!-- endinjector -->
</head>
<body>

  <!-- injector:js -->
  <script src="/file1.js"></script>
  <script src="/file2.js"></script>
  <!-- endinjector -->
</body>
</html>
```
